### PR TITLE
Justify the information block paragraphs

### DIFF
--- a/site/styles.css
+++ b/site/styles.css
@@ -239,6 +239,8 @@ ul {
 
 .information__block p {
   margin-bottom: 1em;
+  text-align: justify;
+  hyphens: auto;
 }
 
 .information__block p:last-of-type {


### PR DESCRIPTION
Justify and auto hyphenate the paragraphs in the information blocks. This will not work on Chrome on Windows, but they'll just see the ugly version (and they're used to ugly fonts anyway… :trollface:) 

Before:

<img width="859" alt="screen shot 2017-03-21 at 08 35 30" src="https://cloud.githubusercontent.com/assets/16063/24136890/6ae73444-0e11-11e7-9437-66a4e291183e.png">

After:

<img width="843" alt="screen shot 2017-03-21 at 08 34 46" src="https://cloud.githubusercontent.com/assets/16063/24136893/7019b824-0e11-11e7-8201-d6523e99c63d.png">
